### PR TITLE
feat: support setting service type

### DIFF
--- a/charts/helm-chart/Chart.yaml
+++ b/charts/helm-chart/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - web
 home: https://portswigger.net/
 sources:
-  - https://github.com/portswigger/enterprise-helm-charts/
+  - https://github.com/peter-svensson/enterprise-helm-charts/
 maintainers:
   - name: Portswigger
     email: hello@portswigger.net

--- a/charts/helm-chart/README.md
+++ b/charts/helm-chart/README.md
@@ -55,6 +55,7 @@ A Helm chart to create the k8s cluster dependencies for BSEE
 | services.webServer.httpsPort | string | `"8443"` |  |
 | services.webServer.installationEnvironment | string | `"KUBERNETES"` |  |
 | services.webServer.label | string | `"app.portswigger.net/ingress: web-server"` |  |
+| services.webServer.type | string | `"ClusterIP"` |  |
 | services.webServer.useDeprecatedHttpConfigFromDatabase | bool | `false` |  |
 | services.webServer.useHttps | bool | `false` |  |
 | support.oracle | bool | `false` |  |

--- a/charts/helm-chart/templates/web-server/service.yml
+++ b/charts/helm-chart/templates/web-server/service.yml
@@ -10,6 +10,7 @@ metadata:
 spec:
   selector:
     app.portswigger.net/name: {{ include "kebabcase-release-name" . }}-web-server
+  type: {{ .Values.services.webServer.type }}
   ports:
     - name: http
       protocol: TCP

--- a/charts/helm-chart/values.yaml
+++ b/charts/helm-chart/values.yaml
@@ -30,6 +30,7 @@ scanContainerMemory: 8Gi
 
 services:
   webServer:
+    type: 'ClusterIP'
     installationEnvironment: KUBERNETES
     label: "app.portswigger.net/ingress: web-server"
     # If set to true, then none of the configuration below will be used, and we will attempt to read the HTTP(S)


### PR DESCRIPTION
To support ingress controllers (like AWS ALB) that requires service.type to be NodePort.