### PR TITLE
Support optional annotations and service type

### DIFF
--- a/charts/helm-chart/README.md
+++ b/charts/helm-chart/README.md
@@ -57,6 +57,8 @@ A Helm chart to create the k8s cluster dependencies for BSEE
 | services.webServer.label | string | `"app.portswigger.net/ingress: web-server"` |  |
 | services.webServer.useDeprecatedHttpConfigFromDatabase | bool | `false` |  |
 | services.webServer.useHttps | bool | `false` |  |
+| services.webServer.annotations | array | `null` | Optional annotations to add to the created service. If omitted, no annotations will be added. |
+| services.webServer.type | string | `null` | Optional service type to create. If omitted, target platform default will be used. |
 | support.oracle | bool | `false` |  |
 | webServerContainerCpu | string | `"1400m"` |  |
 | webServerContainerMemory | string | `"4Gi"` |  |

--- a/charts/helm-chart/templates/web-server/service.yml
+++ b/charts/helm-chart/templates/web-server/service.yml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "kebabcase-release-name" . }}-web-server
   namespace: {{ .Release.Namespace }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{ end -}}
   labels:
     app.kubernetes.io/name: web-server
     app.kubernetes.io/component: server
@@ -10,6 +14,9 @@ metadata:
 spec:
   selector:
     app.portswigger.net/name: {{ include "kebabcase-release-name" . }}-web-server
+{{- if .Values.service.type }}
+  type: {{ .Values.service.type }}
+{{ end -}}
   ports:
     - name: http
       protocol: TCP

--- a/charts/helm-chart/templates/web-server/service.yml
+++ b/charts/helm-chart/templates/web-server/service.yml
@@ -3,9 +3,9 @@ kind: Service
 metadata:
   name: {{ include "kebabcase-release-name" . }}-web-server
   namespace: {{ .Release.Namespace }}
-{{- if .Values.service.annotations }}
+{{- if .Values.services.webServer.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{ toYaml .Values.services.webServer.annotations | indent 4 }}
 {{ end -}}
   labels:
     app.kubernetes.io/name: web-server
@@ -14,8 +14,8 @@ metadata:
 spec:
   selector:
     app.portswigger.net/name: {{ include "kebabcase-release-name" . }}-web-server
-{{- if .Values.service.type }}
-  type: {{ .Values.service.type }}
+{{- if .Values.services.webServer.type }}
+  type: {{ .Values.services.webServer.type }}
 {{ end -}}
   ports:
     - name: http

--- a/charts/helm-chart/templates/web-server/service.yml
+++ b/charts/helm-chart/templates/web-server/service.yml
@@ -5,8 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.services.webServer.annotations }}
   annotations:
-{{ toYaml .Values.services.webServer.annotations | indent 4 }}
-{{ end -}}
+{{ toYaml .Values.services.webServer.annotations | indent 4 -}}
+{{ end }}
   labels:
     app.kubernetes.io/name: web-server
     app.kubernetes.io/component: server
@@ -15,8 +15,8 @@ spec:
   selector:
     app.portswigger.net/name: {{ include "kebabcase-release-name" . }}-web-server
 {{- if .Values.services.webServer.type }}
-  type: {{ .Values.services.webServer.type }}
-{{ end -}}
+  type: {{ .Values.services.webServer.type -}}
+{{ end }}
   ports:
     - name: http
       protocol: TCP


### PR DESCRIPTION
The helm chart today is platform agnostic and establishes an ingress prerequisite. The proposed solution allows consumers to optionally define platform specific needs (annotations and service type). When omitted, the service will deploy exactly as it does today. When present, annotations and/or service type can be defined and controlled by the consumer.

This can allow for AWS and Azure deployments like so:
values.yaml example for AWS:
```
services:
  webServer:
    type: ClusterIP
```
values.yaml example for Azure:
```
services:
  webServer:
    annotations:
      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
    type: LoadBalancer
```

Since these are optional, this is backwards compatible.