### PR TITLE
adding aws load balancer configuration capability

### DIFF
--- a/charts/helm-chart/templates/NOTES.txt
+++ b/charts/helm-chart/templates/NOTES.txt
@@ -1,20 +1,20 @@
 Thank you for installing {{ .Chart.Name }} {{ .Chart.AppVersion }}.
- 
+
 Your release is named {{ .Release.Name }}.
- 
+
 To learn more about the release, try:
- 
+
   $ helm status {{ .Release.Name }}
   $ helm get all {{ .Release.Name }}
- 
+
 {{- $ingressLabel := split ":" .Values.services.webServer.label -}}
 {{- $selectorLabelKey := trim ($ingressLabel._0) -}}
 {{- $selectorLabelValue := trim ($ingressLabel._1) -}}
- 
+
 {{- range $index, $spec := (lookup "v1" "Service" "" "").items -}}
     {{- $selector := .spec.selector -}}
     {{- $selectorValue := get $selector $selectorLabelKey -}}
- 
+
     {{ if eq $selectorValue $selectorLabelValue }}
         {{ $lbIngress := .status.loadBalancer.ingress }}
         {{- if $lbIngress -}}
@@ -28,5 +28,5 @@ To learn more about the release, try:
         {{- end -}}
     {{- end -}}
 {{ end }}
- 
+
 You may need to wait a few minutes for {{ .Chart.Name }} to install before accessing the URL.

--- a/charts/helm-chart/templates/NOTES.txt
+++ b/charts/helm-chart/templates/NOTES.txt
@@ -1,27 +1,32 @@
 Thank you for installing {{ .Chart.Name }} {{ .Chart.AppVersion }}.
-
+ 
 Your release is named {{ .Release.Name }}.
-
+ 
 To learn more about the release, try:
-
+ 
   $ helm status {{ .Release.Name }}
   $ helm get all {{ .Release.Name }}
-
+ 
 {{- $ingressLabel := split ":" .Values.services.webServer.label -}}
 {{- $selectorLabelKey := trim ($ingressLabel._0) -}}
 {{- $selectorLabelValue := trim ($ingressLabel._1) -}}
-
+ 
 {{- range $index, $spec := (lookup "v1" "Service" "" "").items -}}
     {{- $selector := .spec.selector -}}
     {{- $selectorValue := get $selector $selectorLabelKey -}}
-
+ 
     {{ if eq $selectorValue $selectorLabelValue }}
         {{ $lbIngress := .status.loadBalancer.ingress }}
-        {{- $hostName := get (first $lbIngress) "hostname" -}}
-        {{- $ip := get (first $lbIngress) "ip" -}}
-        {{ $url := or $hostName $ip }}
-You can access the application by using https://{{ $url }}/
+        {{- if $lbIngress -}}
+          {{- $hostName := get (first $lbIngress) "hostname" -}}
+          {{- $ip := get (first $lbIngress) "ip" -}}
+          {{ $url := or $hostName $ip }}
+  You can access the application by using https://{{ $url }}/
+        {{- else -}}
+  You appear to be using a non-standard load balancer configuration.
+  Please check your deployment for the correct endpoint address.
+        {{- end -}}
     {{- end -}}
 {{ end }}
-
+ 
 You may need to wait a few minutes for {{ .Chart.Name }} to install before accessing the URL.


### PR DESCRIPTION
When attempting to deploy a cluster in AWS GovCloud it crashes if a variable is not defined. This pull request adds a conditional check to ensure that the variable $lbIngress is defined, prints an alternative message if not, and avoids crashing the deployment. Credit goes to @mark-carey-sap for the suggestion. 